### PR TITLE
Add the ability to set Unicon options globally.

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,18 @@
 import Unicon from './Unicon.vue'
 
 export default {
-  install (Vue, options) {
+  install (Vue, options = {}) {
+
+    const props = Unicon.props
+
+    for (var option in options) {
+      if (props.hasOwnProperty(option)) {
+        Unicon.props[option] = {
+          default: options[option]
+        }
+      }
+    }
+
     Vue.component(Unicon.name, Unicon)
   },
   add (icons) {


### PR DESCRIPTION
Add the ability to customize the Unicon component options globally.
So we can now set the options like so:
```javascript
Vue.use(Unicon, {
  fill: '#414154',
  height: 15,
  width: 15,
})
```